### PR TITLE
Tree interface

### DIFF
--- a/src/main/java/littleCompiler/ParserListener.java
+++ b/src/main/java/littleCompiler/ParserListener.java
@@ -77,14 +77,15 @@ public class ParserListener extends LittleBaseListener {
 		firstArg = argList.getChild(1);
 	    }
 	}
-	exprStack.add(new StmtList());
     }
 
     private void printStack() {
 	System.out.println("the contents of the stack are:");
 	for(ITree e : exprStack) {
-	    System.err.println(e);
+	    System.err.println("Class = " + e.getClass().toString());
+	    e.print();
 	}
+	System.out.println("Done printing stack.");
     }
 
     //A rather morbid function name:
@@ -107,6 +108,13 @@ public class ParserListener extends LittleBaseListener {
 		curTree.addChild(temp);
 	    }
 	}
+    }
+
+    @Override
+    public void exitPrimary(LittleParser.PrimaryContext ctx) {
+       if(ctx.getChild(0).getText().equals("(") ) {
+	    exitMathOperator();
+       }
     }
 
     @Override
@@ -147,6 +155,14 @@ public class ParserListener extends LittleBaseListener {
     }
 
     @Override
+    public void exitExpr(LittleParser.ExprContext ctx) {
+	if(exprStack.peek() instanceof MathExpression) {
+	    exitMathOperator();
+	}
+	
+    }
+    
+    @Override
     public void exitExpr_prefix(LittleParser.Expr_prefixContext ctx) {
 	if(ctx.getChild(2) != null) {
 	    exitMathOperator();
@@ -154,12 +170,8 @@ public class ParserListener extends LittleBaseListener {
     }
 
     @Override
-    public void exitExpr(LittleParser.ExprContext ctx) {
-	exitMathOperator();
-    }
-
-    @Override
-    public void exitAssign_expr(LittleParser.Assign_exprContext ctx) { 
+    public void exitAssign_expr(LittleParser.Assign_exprContext ctx) {
+	
 	Assign asn = new Assign();
 	asn.addChild(ctx.getChild(0).getText());
 	asn.addChild(curTree);
@@ -169,7 +181,6 @@ public class ParserListener extends LittleBaseListener {
 
     @Override
     public void enterStmt_list(LittleParser.Stmt_listContext ctx) {
-	System.out.println("Entering statement");
     }
     
     @Override
@@ -177,28 +188,22 @@ public class ParserListener extends LittleBaseListener {
 	if(ctx.getChild(0) != null) {
 	    ITree lst = null;
 	    if(!(exprStack.peek() instanceof StmtList)) {
-		System.out.println("Creating new list");
 		lst = new StmtList();
 	    } else {
 		lst = exprStack.pop();
 	    }
 	    ITree expr = exprStack.pop();
-	    System.out.println("expr: " + expr);
-	    System.out.println("lst: " + lst);
 	    lst.addChild(expr);
 	    exprStack.push(lst);
-	    printStack();
 	}
     }
 
     @Override
     public void enterWrite_stmt(LittleParser.Write_stmtContext ctx) {
-	exprStack.push(new StmtList());
     }
     
     @Override
     public void enterRead_stmt(LittleParser.Read_stmtContext ctx) {
-	exprStack.push(new StmtList());
     }
     
     @Override

--- a/src/main/java/littleCompiler/ast/Assign.java
+++ b/src/main/java/littleCompiler/ast/Assign.java
@@ -22,6 +22,11 @@ public class Assign implements ITree {
 	return expr != null && location != null;
     }
 
+    public void print() {
+	System.out.println(this);
+
+    }
+
     public String toString() {
 	return location + " = " + expr;
     }

--- a/src/main/java/littleCompiler/ast/ITree.java
+++ b/src/main/java/littleCompiler/ast/ITree.java
@@ -3,4 +3,5 @@ package littleCompiler.ast;
 public interface ITree {
     public void addChild(Object child);
     public boolean isFull();
+    public void print();
 }

--- a/src/main/java/littleCompiler/ast/MathExpression.java
+++ b/src/main/java/littleCompiler/ast/MathExpression.java
@@ -21,7 +21,11 @@ public class MathExpression implements ITree {
     }
 
     public boolean isFull() {
-	return left != null && right != null;
+	return (left != null && right != null);
+    }
+
+    public void print() {
+	System.out.println(this);
     }
 
     @Override

--- a/src/main/java/littleCompiler/ast/StmtList.java
+++ b/src/main/java/littleCompiler/ast/StmtList.java
@@ -17,4 +17,13 @@ public class StmtList implements ITree {
     public void addChild(Object child) {
 	stmts.addLast(child);
     }
+
+    public void print() {
+	System.out.println("This is a statement list:");
+	for(ITree t : stmts) {
+	    t.print();
+	}
+	System.out.println("Done printing the list");
+    }
+	
 }

--- a/src/main/java/littleCompiler/ast/StmtList.java
+++ b/src/main/java/littleCompiler/ast/StmtList.java
@@ -4,10 +4,10 @@ import java.util.LinkedList;
 import java.util.Deque;
 
 public class StmtList implements ITree {
-    private Deque stmts;
+    private Deque<ITree> stmts;
 
     public StmtList() {
-	stmts = new LinkedList();
+	stmts = new <ITree>LinkedList();
     }
 
     public boolean isFull() {
@@ -15,7 +15,7 @@ public class StmtList implements ITree {
     }
 
     public void addChild(Object child) {
-	stmts.addLast(child);
+	stmts.addFirst( (ITree)child);
     }
 
     public void print() {


### PR DESCRIPTION
Fixed the errors in expression and statement building. The program was calling `exitMathExpression()` too often, causing the stack to contain the wrong elements.

In addition, the StmtList was saving the statements in the wrong order.